### PR TITLE
Manipulating Arrays v.2

### DIFF
--- a/collections_practice.rb
+++ b/collections_practice.rb
@@ -1,0 +1,75 @@
+def test_i
+  [1,2,3,4,5,6]
+end
+
+def test_s
+  ["vampire", "apple", "christmas", "skull"]
+end
+
+def sort_array_asc(array)
+  array.sort
+end
+
+def sort_array_desc(array)
+  array.sort.reverse!
+end
+
+def sort_array_char_count(array)
+  array.sort_by {|x| x.length}
+end  
+
+def swap_elements(array)
+array[1], array[2] = array[2], array[1]
+array
+end  
+
+def swap_elements_from_to(array, index, tar_index) #you can choose which elements are switched
+  array[index], array[tar_index] = array[tar_index], array[index]
+  array
+end
+
+def reverse_array(array)
+  array.reverse
+end
+
+def kesha_maker(array)
+  array.collect {|x| x.sub(/(?<=..)./, "$")} #positive lookbehind
+end
+
+def find_a(array)
+  hey = []
+  array.each do |x|
+    if x.downcase.start_with?("a") == true #downcase for control
+      hey << x
+    end
+  end
+  hey
+end
+
+def sum_array(array)
+array.inject {|sum, a| sum += a} #inject is new
+end
+
+def add_s(array)
+  array.each {|x| 
+    if x != array[1]
+      x << "s"
+    end
+    }
+
+end
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+         


### PR DESCRIPTION
I was introduced to a few new tricks in ruby today. These new challenges came in the form of Questions 4, 6, 7, 8, and 9. 

**4.** Required me to swap elements in an array, here is the code: 

```
def swap_elements(array)
array[1], array[2] = array[2], array[1]
array
end  

def swap_elements_from_to(array, index, tar_index) #you can choose which elements are switched
  array[index], array[tar_index] = array[tar_index], array[index]
  array
end
```

Here you type the array items you wish to switch as they exist numerically ordered on the left, then you set them equal to the way you would like them swapped on the right side of the `=` sign. The second method `swap_elements_from_to(array, index, tar_index) is just a way to write this same method with a little more control from the beginning as to which array items you are looking to swap.

[Here is the source I used to pass the test.](https://dzone.com/articles/swap-elements-array-ruby)

**6.** The Ke$ha Maker.

```
def kesha_maker(array)
  array.collect {|x| x.sub(/(?<=..)./, "$")} #positive lookbehind
end
```

This is the first time I have encountered ["Positive Lookbehind".](http://stackoverflow.com/questions/24344892/using-gsub-or-sub-to-replace-one-character) So as the explanation of the first answer points out the periods seem to be acting a placeholders for the characters. According to some testing after the lab I was able to determine that wherever the closing parenthesis is located is where the substitution will take place in the element relative to the first period symbol going backwards. For example `(?<=..)., "$")` is the third spot, or index[2]. '(?<=....)., "$")` will be the fifth, or index[4].
**NOTE: you are not iterating though an array, rather the characters in the elements of the array.**

A different way to use positive lookbehind is this way:

```
"Hiiiii".sub!(/(?<=.{2})./, &:upcase)
# => "HiIiii"

"Hello".sub!(/(?<=.{2})./, &:upcase)
# => "HeLlo"
```

This just requires the initial `.` and the desired index number surrounded by curly brackets between another `.` I don't understand this `.sub` thing entirely, but that's the best way I can describe it.

**7.** Finding all the elements in an array that begin with "a", or is it "A"? I used this code: 

```
def find_a(array)
  hey = []
  array.each do |x|
    if x.downcase.start_with?("a") == true #downcase for control
      hey << x
    end
  end
  hey
end
```

This was an easier problem to solve, this is my usual "long way around" `.collect` method. I thought I could solve this easily using `.collect` initially it didn't work out. I tried a bunch of different things I thought might work, but they did not. I learned more about the `.start_with?(argument)` method [at this web page.](http://apidock.com/ruby/String/start_with%3F)

**8.** Adding together all the elements in an array, luckily of integers. Here it is: 

```
def sum_array(array)
array.inject {|sum, a| sum += a} #inject is new
end
```

I have never used `.inject` but I understand how it is nifty at least in this case. [Here is more about it in ruby-doc.org apparently it's an enumerator.](http://ruby-doc.org/core-2.2.3/Enumerable.html) [This seems like a better source I'm reading up on it right now...](http://blog.jayfields.com/2008/03/ruby-inject.html) According to this source the way that `.inject` works is by taking in an array and a block. In the above case they are `array` and `{|sum , a| sum += a }` respectively. `.inject` can take in an argument `.inject(here)` and that would be the initial `sum` value, however without passing `.inject` an argument the first `sum` value is the first element in the array, in this case it was 1. So `.inject` goes through each item in the array. The first `a` element is added to `sum`, once that is done `.inject` moves onto the second element and adds that to the `sum` value and so on and so forth. This may be a bit much but here it goes:

```
test = [1,2,3,4,5]
test.inject {| sum ,  x | sum += x }

inject(1) + 2 = inject(3)
inject(3) + 3 = inject(6)
inject(6) + 4 = inject(10)
inject(10) + 5 = inject(15)
### No more items in the array ###
=> 15
```

**9** So fine, add an "s" to each element in an array except the second, of array[1]- here is how I did it:

```
def add_s(array)
  array.each {|x| 
    if x != array[1]
      x << "s"
    end
    }
end
```

Pardon the throwback to that CSS formatting, but it seemed cool and I was better able to visualize 
`}` = `end`. [I needed to look up how to add onto strings](http://www.rubyfleebie.com/appending-to-a-string/) luckily my old friend the shovel operator can work on arrays and strings! Once I was (_cough, cough_) reminded of that fact this was an easier challenge. Iterate through the whole array, if `x` is not the second item in the index slap an `"s"` in there, no biggie.
